### PR TITLE
Added wrapper script

### DIFF
--- a/#README.md#
+++ b/#README.md#
@@ -1,0 +1,29 @@
+# Betty
+
+[![Build Status](https://travis-ci.org/holbertonschool/Betty.svg?branch=master)](https://travis-ci.org/holbertonschool/Betty)
+
+### Installation
+
+Run the script `install.sh` with **sudo privileges** to install `betty-style`, `betty-doc` and the `betty` wrapper script on your computer, along with the following manuals:
+
+ * _betty(1)_
+ * _betty-style(1)_
+ * _betty-doc(1)_
+
+### Documentation
+
+Please visit the [Betty Wiki](https://github.com/holbertonschool/Betty/wiki) for the full specifications of Betty coding and documentation styles.
+
+You'll also find some references and some tools for common text editors such as Emacs and Atom.
+
+### Usage
+
+Run the following command to check if your code/doc fits the Betty Style (mostly inspired b the Linux Kernel style):
+
+```ShellSession
+./betty-style.pl file1 [file2 [file3 [...]]]
+```
+
+```ShellSession
+./betty-doc.pl file1 [file2 [file3 [...]]]
+```

--- a/betty.sh
+++ b/betty.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Simply a wrapper script to keep you from having to use betty-style
+# and betty-doc separately on every item.
+# Originally by Tim Britton (@wintermanc3r), multiargument added by
+# Larry Madeo (@hillmonkey)
+
+BIN_PATH="/usr/local/bin"
+BETTY_STYLE="betty-style"
+BETTY_DOC="betty-doc"
+
+if [ "$#" = "0" ]; then
+    echo "No arguments passed."
+    exit 1
+fi
+
+for argument in "$@" ; do
+    echo -e "\n========== $argument =========="
+    ${BIN_PATH}/${BETTY_STYLE} "$argument"
+    ${BIN_PATH}/${BETTY_DOC} "$argument"
+done

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ fi
 
 BETTY_STYLE="betty-style"
 BETTY_DOC="betty-doc"
+BETTY_WRAPPER="betty"
 
 APP_PATH="/opt/betty"
 BIN_PATH="/usr/local/bin"
@@ -19,12 +20,15 @@ mkdir -p "${APP_PATH}"
 
 cp "${BETTY_STYLE}.pl" "${APP_PATH}/${BETTY_STYLE}"
 cp "${BETTY_DOC}.pl" "${APP_PATH}/${BETTY_DOC}"
+cp "${BETTY_WRAPPER}.sh" "${APP_PATH}/${BETTY_WRAPPER}"
 
 chmod +x "${APP_PATH}/${BETTY_STYLE}"
 chmod +x "${APP_PATH}/${BETTY_DOC}"
+chmod +x "${APP_PATH}/${BETTY_WRAPPER}"
 
 ln -s "${APP_PATH}/${BETTY_STYLE}" "${BIN_PATH}/${BETTY_STYLE}"
 ln -s "${APP_PATH}/${BETTY_DOC}" "${BIN_PATH}/${BETTY_DOC}"
+ln -s "${APP_PATH}/${BETTY_WRAPPER}" "${BIN_PATH}/${BETTY_WRAPPER}"
 
 echo -e "Installing man pages.."
 


### PR DESCRIPTION
Hey!

I made a wrapper script (so you can just use `betty` <file> and not `betty-style` <file>, `betty-doc` <file> separately) awhile ago and a bunch of people are using it now.

So I'm just making a quick PR to add a wrapper script (multi-arg support added by @hillmonkey who suggested I make a PR) and update the install script to add it. Let me know if it would be helpful.