### PR TITLE
[fix]: deprecated syntax left brace warning

### DIFF
--- a/betty-doc.pl
+++ b/betty-doc.pl
@@ -2035,7 +2035,7 @@ sub dump_struct($$) {
 	my $members = $3;
 
 	# ignore embedded structs or unions
-	$members =~ s/({.*})//g;
+	$members =~ s/(\{.*})//g;
 	$nested = $1;
 
 	# ignore members marked private:


### PR DESCRIPTION
Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/({ <-- HERE .*})/ at /usr/local/bin/betty-doc line 2038.