### PR TITLE
[fix]: unscaped left brace warning

### DIFF
--- a/betty-style.pl
+++ b/betty-style.pl
@@ -3913,7 +3913,7 @@ sub process {
 
 # check number of functions
 # and number of lines per function
-		if ($line =~ /({)/g) {
+		if ($line =~ /(\{)/g) {
 			$inscope += $#-;
 			if ($funcprotovalid && $inscope == 1) {
 				$infunc = 1;


### PR DESCRIPTION
Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/({ <-- HERE )/ at /usr/local/bin/betty-style line 3916.