### PR TITLE
Fix: Handle nested single line scopes

### DIFF
--- a/betty-style.pl
+++ b/betty-style.pl
@@ -3603,9 +3603,13 @@ sub process {
 		if ($line !~ /^\+\s*#/ &&
 		    $line !~ /^\+\s*$/ &&
 		    $line !~ /^\+ +/) {
-			my $expected_indent = $realscope + $onelinescope + $incond + $inparams;
+			my $expected_indent = $realscope + $incond + $inparams;
 			$expected_indent-- if ($line =~ /^\+\s*(case\s+\S+|default)\s*:/);
-			# print "[$expected_indent] <$line>\n\t$realscope | $onelinescope | $incond | $inparams\n";
+			# print "[$expected_indent] <$line>\n\t$realscope | $incond | $inparams\n";
+
+			if ($onelinescope != 0) {
+				$expected_indent = ($previndent / 8) + 1;
+			}
 
 			my $line_indent = $indent;
 			if ($rawline =~ /^\+\s*( +)\*/) {

--- a/tests/style/indentation/indentation1.c
+++ b/tests/style/indentation/indentation1.c
@@ -27,6 +27,12 @@ int main(int argc, char *argv[])
 		return (1);
 	}
 
+	if (1 < 1 + 1)
+		if (!func(1, 2))
+			if (!func(1, 2))
+				if (!func(1, 2))
+					return (0);
+
 	if (1 <= 2)
 		num1 = atoi(argv[1]);
 	num2 = atoi(argv[2]);


### PR DESCRIPTION
Betty should recognize nested single-line scopes after conditions, like the following:

```c
if (1 < 1 + 1)
	if (!func(1, 2))
		if (!func(1, 2))
			if (!func(1, 2))
				return (0);
```

Before this fix, Betty only accounted for 1 level of single-line scope. It now handles nested single-line scopes.