### PR TITLE
Fix  Command Not Found Error on macOS During Installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 
 if [ "$(id -u)" != "0" ]
 then
-	echo "Sorry, you are not root."
-	exit 1
+    echo "Sorry, you are not root."
+    exit 1
 fi
 
 BETTY_STYLE="betty-style"
@@ -40,6 +40,11 @@ cp "man/${BETTY_DOC}.1" "${MAN_PATH}"
 
 echo -e "Updating man database.."
 
-mandb
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    mandb
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "On macOS, 'mandb' is not required. Skipping this step."
+fi
 
 echo -e "All set."
+


### PR DESCRIPTION
# Pull Request: `mandb` Command Not Found on macOS During Installation

## Problem
During the installation of Betty, the script executes the `mandb` command, which is unavailable on macOS. This results in the error `mandb: command not found`. This issue causes confusion among macOS users, as it may appear that the installation process has failed.

## Proposed Solution
The installation script should be modified to:
- Detect the operating system.
- On macOS (identified by `OSTYPE` as `darwin`), skip the `mandb` command and display a message indicating the step is unnecessary.
- On Linux, execute `mandb` as usual.

## Testing
- The modified script has been tested on both macOS and Linux.
- On macOS, the script skips the `mandb` step and displays a message.
- On Linux, the script executes `mandb` without issues.

## Impact
This change ensures a smoother installation experience on macOS and maintains the current functionality on Linux.

