### PR TITLE
Fix false positive on "bare unsigned" detection (-> adding word boundaries around)

### DIFF
--- a/betty-style.pl
+++ b/betty-style.pl
@@ -3498,7 +3498,7 @@ sub process {
 			my $type = $1;
 			my $var = $2;
 			$var = "" if (!defined $var);
-			if ($type =~ /^(?:(?:$Storage|$Inline|$Attribute)\s+)*((?:un)?signed)((?:\s*\*)*)\s*$/) {
+			if ($type =~ /^(?:(?:$Storage|$Inline|$Attribute)\s+)*\b((?:un)?signed)\b((?:\s*\*)*)\s*$/) {
 				my $sign = $1;
 				my $pointer = $2;
 


### PR DESCRIPTION
Hello, nice to meet you! Hereunder summary of problem and reasoning behind suggested fix.

### Error encountered
Betty wrongly detect use of "bare unsigned" and recommend unsigned int on a line just declaring the use of a function print_unsigned.
Example: 	table['u'] = print_unsigned;
Betty error: _printf.c:26: WARNING: Prefer 'unsigned int' to bare use of 'unsigned'

### Diagnosis
The regex trying to find is not sufficiently restrictive.

### Suggested fix
Adding word boundaries around unsigned to stop matching things like `_unsigned` or `unsigned_`. 

Note: as I didn't study the ins and outs of that program I am not sure that my fix resolves this use-case without harming another.